### PR TITLE
Cache files for gulp lint\format and created gulp help

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,22 +1,27 @@
 // grab our packages
-var gulp   = require('gulp'),
-beautify = require('gulp-jsbeautifier'),
-sourcemaps = require('gulp-sourcemaps'),
-sass = require('gulp-sass'),
-minifyCSS = require('gulp-minify-css'),
-rename = require('gulp-rename'),
-prettify = require('gulp-jsbeautifier'),
-jshint = require('gulp-jshint'),
-concat = require('gulp-concat'),
-livereload = require('gulp-livereload'),
-server = require('gulp-develop-server'),
-shell = require('gulp-shell'),
-jscs = require('gulp-jscs'),
-argv = require('yargs').argv,
-gutil = require('gulp-util');
+var gulp = require('gulp-help')(require('gulp'), {
+        description: 'you are looking at it.',
+        aliases: ['h']
+    }),
+    colors = require('colors'),
+    beautify = require('gulp-jsbeautifier'),
+    sourcemaps = require('gulp-sourcemaps'),
+    sass = require('gulp-sass'),
+    minifyCSS = require('gulp-minify-css'),
+    rename = require('gulp-rename'),
+    prettify = require('gulp-jsbeautifier'),
+    jshint = require('gulp-jshint'),
+    concat = require('gulp-concat'),
+    livereload = require('gulp-livereload'),
+    server = require('gulp-develop-server'),
+    shell = require('gulp-shell'),
+    jscs = require('gulp-jscs'),
+    argv = require('yargs').argv,
+    gutil = require('gulp-util');
 
+var indent = '                        ';
 var options = {
-  path: './server.js'
+    path: './server.js'
 };
 var FILES = {};
 FILES.FRONTEND_JS = ['./public/app/**/*.js'];
@@ -31,76 +36,99 @@ FILES.JS_ALL = [].concat(FILES.FRONTEND_JS, FILES.SERVER_JS);
 FILES.LINT = [].concat(FILES.FRONTEND_JS, FILES.SERVER_JS_WITHOUT_MAIN);
 
 // define the default task and add the watch task to it
-gulp.task('default', ['watch']);
+gulp.task('default', colors.bgCyan.black('gulp') + ' === ' + colors.bgCyan.black('gulp watch'), ['watch']);
 
 // configure the jshint task
-gulp.task('lint-js', function() {
-  return gulp.src(FILES.JS_ALL)
-  .pipe(jscs())
-  .pipe(jscs.reporter());
+gulp.task('lint-js', 'lint ' + colors.blue('all JS') + ' files in the following paths:\n' + indent +
+    colors.yellow(FILES.JS_ALL.join(',\n' + indent)),
+    function() {
+        return gulp.src(FILES.JS_ALL)
+            .pipe(jscs())
+            .pipe(jscs.reporter());
+    });
+
+gulp.task('lint-sass', 'lint ' + colors.blue('all SASS') + ' files in the following paths:\n' + indent +
+    colors.yellow(FILES.FRONTEND_SASS.join(',\n' + indent)),
+    function() {
+        return gulp.src(FILES.FRONTEND_SASS)
+            .pipe(sass().on('error', sass.logError));
+    });
+
+gulp.task('lint', 'lint ' + colors.blue('all javascript and sass') + ' files', ['lint-js', 'lint-sass']);
+
+gulp.task('format-front-end', 'formats the FE files in the following paths:\n' + indent +
+    colors.yellow(FILES.FRONTEND_JS.join(',\n' + indent)),
+    function() {
+        return gulp.src([].concat(FILES.FRONTEND_JS), {
+                base: 'public'
+            })
+            .pipe(jscs({
+                fix: true
+            }))
+            .pipe(jscs.reporter())
+            .pipe(gulp.dest('./public')); // add this to a different folder in order to test first
+    });
+
+gulp.task('format-server', 'formats the BE files in the following paths:\n' + indent +
+    colors.yellow([].concat(FILES.SERVER_JS, FILES.BUILD_FILES).join(',\n' + indent)),
+    function() {
+        return gulp.src([].concat(FILES.SERVER_JS, FILES.BUILD_FILES), {
+                base: '.'
+            })
+            .pipe(jscs({
+                fix: true
+            }))
+            .pipe(jscs.reporter())
+            .pipe(gulp.dest('.'));
+    });
+
+gulp.task('format', 'formats ' + colors.blue('all') + ' the project\'s javascript files', ['format-server', 'format-front-end']);
+
+gulp.task('styles', 'compile SASS to CSS', function() {
+    return gulp.src(FILES.FRONTEND_SASS)
+        .pipe(sourcemaps.init())
+        .pipe(sass().on('error', sass.logError))
+        .pipe(concat('style.css'))
+        //.pipe(minifyCSS())
+        .pipe(sourcemaps.write())
+        //.pipe(rename({ suffix: '.min' }))
+        .pipe(gulp.dest('./public/assets/css/'));
 });
 
-gulp.task('lint-sass', function() {
-  return gulp.src(FILES.FRONTEND_SASS)
-  .pipe(sass().on('error', sass.logError));
+gulp.task('serve', 'start the Kibibit Code Editor server', ['styles'], function() {
+    server.listen(options, livereload.listen);
 });
 
-gulp.task('lint', ['lint-js', 'lint-sass']);
-
-gulp.task('format-front-end', function() {
-  return gulp.src([].concat(FILES.FRONTEND_JS), {
-    base: 'public'
-  })
-	.pipe(jscs({fix: true}))
-	.pipe(jscs.reporter())
-	.pipe(gulp.dest('./public')); // add this to a different folder in order to test first
-});
-
-gulp.task('format-server', function() {
-  return gulp.src([].concat(FILES.SERVER_JS, FILES.BUILD_FILES), {
-    base: '.'
-  })
-	.pipe(jscs({fix: true}))
-	.pipe(jscs.reporter())
-	.pipe(gulp.dest('.'));
-});
-
-gulp.task('format', ['format-server', 'format-front-end']);
-
-gulp.task('styles', function() {
-  return gulp.src(FILES.FRONTEND_SASS)
-  .pipe(sourcemaps.init())
-  .pipe(sass().on('error', sass.logError))
-  .pipe(concat('style.css'))
-  //.pipe(minifyCSS())
-  .pipe(sourcemaps.write())
-  //.pipe(rename({ suffix: '.min' }))
-  .pipe(gulp.dest('./public/assets/css/'));
-});
-
-gulp.task('serve', ['styles'], function() {
-  server.listen(options, livereload.listen);
-});
-
-gulp.task('debug', ['styles'], shell.task(['node-debug server.js']));
+gulp.task('debug', 'debug the project using ​' + colors.blue('~= node-inspector =~'), ['styles'], shell.task(['node-debug server.js']));
 
 // configure which files to watch and what tasks to use on file changes
-gulp.task('watch', ['serve'], function() {
-  function restart(file) {
-    server.changed(function(error) {
-      if (!error) {
-        reloadBrowser('Backend file changed.', file.path);
-      }
+gulp.task('watch', 'first, will compile SASS and run the server.\n' + indent +
+    'Then, it watches changes and do the following things when needed:\n' + indent +
+    colors.yellow('  1.') + ' compile SASS\n' + indent +
+    colors.yellow('  2.') + ' restart server\n' + indent +
+    colors.yellow('  3.') + ' reload browser', ['serve'],
+    function() {
+        function restart(file) {
+            server.changed(function(error) {
+                if (!error) {
+                    reloadBrowser('Backend file changed.', file.path);
+                }
+            });
+        }
+
+        function reloadBrowser(message, path) {
+            gutil.log(message ? message : 'Something changed.', gutil.colors.bgBlue.white.bold('Reloading browser...'));
+            livereload.changed(path);
+        }
+
+        gulp.watch(argv.lint ? FILES.LINT : [], ['lint-js']);
+        gulp.watch(FILES.FRONTEND_SASS, ['styles']);
+        gulp.watch(FILES.SERVER_JS).on('change', restart);
+        gulp.watch(FILES.FRONTEND_ALL).on('change', function(file) {
+            reloadBrowser('Frontend file changed.', file.path);
+        });
+    }, {
+        options: {
+            'lint': 'will include output from linter only for changed files'
+        }
     });
-  }
-
-  function reloadBrowser(message, path) {
-    	gutil.log(message ? message : 'Something changed.', gutil.colors.bgBlue.white.bold('Reloading browser...'));
-    	livereload.changed(path);
-  }
-
-  gulp.watch(argv.lint ? FILES.LINT : [], ['lint-js']);
-  gulp.watch(FILES.FRONTEND_SASS, ['styles']);
-  gulp.watch(FILES.SERVER_JS).on('change', restart);
-  gulp.watch(FILES.FRONTEND_ALL).on('change', function(file) {reloadBrowser('Frontend file changed.', file.path);});
-});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,6 +17,7 @@ var gulp = require('gulp-help')(require('gulp'), {
     shell = require('gulp-shell'),
     jscs = require('gulp-jscs'),
     argv = require('yargs').argv,
+    cache = require('gulp-cached'),
     gutil = require('gulp-util');
 
 var indent = '                        ';
@@ -43,6 +44,7 @@ gulp.task('lint-js', 'lint ' + colors.blue('all JS') + ' files in the following 
     colors.yellow(FILES.JS_ALL.join(',\n' + indent)),
     function() {
         return gulp.src(FILES.JS_ALL)
+            .pipe(cache('linting'))
             .pipe(jscs())
             .pipe(jscs.reporter());
     });
@@ -51,6 +53,7 @@ gulp.task('lint-sass', 'lint ' + colors.blue('all SASS') + ' files in the follow
     colors.yellow(FILES.FRONTEND_SASS.join(',\n' + indent)),
     function() {
         return gulp.src(FILES.FRONTEND_SASS)
+            .pipe(cache('linting'))
             .pipe(sass().on('error', sass.logError));
     });
 
@@ -62,6 +65,7 @@ gulp.task('format-front-end', 'formats the FE files in the following paths:\n' +
         return gulp.src([].concat(FILES.FRONTEND_JS), {
                 base: 'public'
             })
+            .pipe(cache('formating'))
             .pipe(jscs({
                 fix: true
             }))
@@ -75,6 +79,7 @@ gulp.task('format-server', 'formats the BE files in the following paths:\n' + in
         return gulp.src([].concat(FILES.SERVER_JS, FILES.BUILD_FILES), {
                 base: '.'
             })
+            .pipe(cache('formating'))
             .pipe(jscs({
                 fix: true
             }))

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "gulp-beautify": "~1.1.2",
+    "gulp-cached": "^1.1.0",
     "gulp-concat": "~2.6.0",
     "gulp-develop-server": "~0.5.0",
     "gulp-help": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -25,22 +25,23 @@
     "user-home": "^2.0.0"
   },
   "devDependencies": {
-    "jshint-stylish": "~2.0.1",
-    "gulp-jshint": "~1.11.2",
     "gulp-beautify": "~1.1.2",
-    "gulp-jsbeautifier": "~1.0.1",
-    "gulp-sass": "~2.0.4",
-    "gulp-rename": "~1.2.2",
-    "gulp-minify-css": "~1.2.1",
-    "gulp-sourcemaps": "~1.5.2",
     "gulp-concat": "~2.6.0",
-    "gulp-livereload": "~3.8.1",
     "gulp-develop-server": "~0.5.0",
-    "gulp-util": "~3.0.7",
-    "gulp-shell": "~0.5.1",
+    "gulp-help": "^1.6.1",
+    "gulp-jsbeautifier": "~1.0.1",
     "gulp-jscs": "~3.0.2",
+    "gulp-jshint": "~1.11.2",
+    "gulp-livereload": "~3.8.1",
+    "gulp-minify-css": "~1.2.1",
+    "gulp-rename": "~1.2.2",
+    "gulp-sass": "~2.0.4",
+    "gulp-shell": "~0.5.1",
+    "gulp-sourcemaps": "~1.5.2",
+    "gulp-util": "~3.0.7",
     "jscs": "~2.7.0",
     "jscs-angular": "~1.2.1",
+    "jshint-stylish": "~2.0.1",
     "yargs": "~3.31.0"
   }
 }


### PR DESCRIPTION
run `gulp help` to see all tasks with documentation. This also add the doc to the code which is nice :-)

Also, added cache to `gulp lint` and `gulp format`. Now, from the second run, only the changed files will be linted \ formated

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kibibit/kibibit-code-editor/36)
<!-- Reviewable:end -->
