### PR TITLE
Temporary fix for sidebar overflow

### DIFF
--- a/public/assets/sass/_components/_sidebar.scss
+++ b/public/assets/sass/_components/_sidebar.scss
@@ -7,6 +7,8 @@
 	float: left;
 	background-color: #555;
 	font-size: 70%;
+	overflow-y: auto;
+	overflow-x: hidden;
 	.sidebar-header {
 		color: rgb(221, 221, 221);
 	}


### PR DESCRIPTION
Currently, there is no real separation between the sidebar and the tree inside of it. When the tree and sidebar will be encapsulated, We'll change this overflow style to the tree container, & the sidebar won't have a scrollbar