### PR TITLE
fix loading bar styling and disable some lint rules

### DIFF
--- a/public/assets/sass/style.scss
+++ b/public/assets/sass/style.scss
@@ -1,3 +1,6 @@
+// scss-lint:disable NestingDepth
+// scss-lint:disable SelectorDepth
+
 // BASIC COLORS
 $precentage: 10%;
 // DARK
@@ -97,6 +100,7 @@ body,
   display: flex;
   flex-direction: column;
   flex-wrap: nowrap;
+  overflow: hidden;
 }
 
 .tabs {
@@ -183,3 +187,23 @@ treecontrol {
   background-image: url("../images/error.png") !important;
   background-size: contain;
 }
+
+// scss-lint:disable IdSelector
+#loading-bar-spinner .spinner-icon {
+  border: solid 4px transparent;
+  border-left-color: $primary;
+  border-top-color: $primary;
+  height: 16px;
+  width: 16px;
+}
+
+#loading-bar .bar {
+  background: $primary;
+  height: 4px;
+  .peg {
+    display: none;
+  }
+}
+// scss-lint:enable IdSelector
+// scss-lint:enable NestingDepth
+// scss-lint:enable SelectorDepth


### PR DESCRIPTION
# Change Summary

 - Disable some `scss-lint` rules for now (do that in a config file later)
 - Make the loading bar and loading circle be bigger and in our primary color

Before you submit a PR, make sure you did the following things:
- [x] did you link this PR to an issue?
- [x] did you lint your changes to both javascript and scss?
- [x] "I'm pretty sure I'll be able to read and understand this PR, even if I wasn't the author." - ***said the PR author***

Currently, the `style.scss` file contains all of our override styles. we need to move this to another file to have the lint disabled for those only. The only thing we need to disable globally later is the `NestingDepth` and `SelectorDepth` rules

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kibibit/kibibit-code-editor/92)
<!-- Reviewable:end -->