### PR TITLE
toggle material icon with isFullscreen setting

### DIFF
--- a/public/app/components/menuBar/menuBarTemplate.html
+++ b/public/app/components/menuBar/menuBarTemplate.html
@@ -138,7 +138,7 @@
                         <md-menu-divider></md-menu-divider>
                         <md-menu-item type="checkbox" ng-model="menuBarCtrl.settings.compactControls">Compact controls</md-menu-item>
                         <md-menu-item class="md-indent">
-                            <md-icon class="material-icons">fullscreen</md-icon>
+                            <md-icon class="material-icons">{{ main.settings.isFullscreen ? 'fullscreen_exit' : 'fullscreen' }}</md-icon>
                             <md-button ng-click="main.goFullscreen()">
                                 Fullscreen
                                 <span class="md-alt-text"> {{ 'F12' | keyboardShortcut }}</span>

--- a/public/app/controllers/mainCtrl.js
+++ b/public/app/controllers/mainCtrl.js
@@ -108,7 +108,7 @@ angular.module('kibibitCodeEditor')
         Fullscreen.all();
         SettingsService.setSettings({
           isFullscreen: true
-        })
+        });
       }
     };
 

--- a/public/app/controllers/mainCtrl.js
+++ b/public/app/controllers/mainCtrl.js
@@ -100,9 +100,15 @@ angular.module('kibibitCodeEditor')
     vm.goFullscreen = function() {
 
       if (Fullscreen.isEnabled()) {
+        SettingsService.setSettings({
+          isFullscreen: false
+        });
         Fullscreen.cancel();
       } else {
         Fullscreen.all();
+        SettingsService.setSettings({
+          isFullscreen: true
+        })
       }
     };
 

--- a/public/app/services/settingsService.js
+++ b/public/app/services/settingsService.js
@@ -5,7 +5,8 @@ angular.module('kibibitCodeEditor')
 
   /* init */
   var settings = {
-    cursor: {row: '0', column: '0'}
+    cursor: {row: '0', column: '0'},
+    isFullscreen: false
   };
 
   vm.getSettings = function() {


### PR DESCRIPTION
# Change Summary
[resolves #93]
 - Added a `settings` entry called `isFullscreen` to indicate the state of fullscreen-ess (? :stuck_out_tongue_winking_eye: )
 
 > When settings will be backed-up to server, this one should stay client side only. I don't think it's the right behaviour for an app to save it's fullscreen state (maybe on native wrapper. but not for now)
 
 - Made the `fullscreen` entry in the `menuBar` component toggle the icon according to the right `isFullscreen` state
 

Before you submit a PR, make sure you did the following things:
- [x] did you link this PR to an issue?
- [x] did you lint your changes to both javascript and scss?
- [x] "I'm pretty sure I'll be able to read and understand this PR, even if I wasn't the author." - ***said the PR author***

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kibibit/kibibit-code-editor/94)
<!-- Reviewable:end -->
