### PR TITLE
fix scroll for project modal after file tree encapsulation

### DIFF
--- a/public/app/components/codeEditor/codeEditorTemplate.html
+++ b/public/app/components/codeEditor/codeEditorTemplate.html
@@ -1,4 +1,3 @@
 <div class="editor"
      ui-ace="codeEditorCtrl.editorOptions"
-     ng-model="codeEditorCtrl.code"></div> <!-- kb-change-ace-scroll -->
-<div kb-change-ace-scroll ng-scrollbars></div>
+     ng-model="codeEditorCtrl.code"></div>

--- a/public/app/components/projectFolderModal/projectFolderModalTemplate.html
+++ b/public/app/components/projectFolderModal/projectFolderModalTemplate.html
@@ -1,4 +1,4 @@
-<div class="project-tree-container" ng-scrollbars>
+<div class="project-tree-container" ng-if="ngDialogData.userHomeDirectoryPath" ng-scrollbars>
   <kb-file-tree
     kb-file-tree-path="ngDialogData.userHomeDirectoryPath" 
     kb-file-tree-options="{selectionMode: 'folder', theme: 'tree'}"

--- a/public/app/controllers/mainCtrl.js
+++ b/public/app/controllers/mainCtrl.js
@@ -47,7 +47,8 @@ angular.module('kibibitCodeEditor')
     };
 
     vm.isModalCancel = function(closeValue) {
-      return angular.isNumber(closeValue) && closeValue === 0;
+      return (angular.isNumber(closeValue) && closeValue === 0)
+              || (angular.isString(closeValue) && (closeValue === '$document' || closeValue === '$closeButton'));
     };
 
     // show the default projects directory to choose a folder from

--- a/public/app/controllers/mainCtrl.js
+++ b/public/app/controllers/mainCtrl.js
@@ -48,7 +48,9 @@ angular.module('kibibitCodeEditor')
 
     vm.isModalCancel = function(closeValue) {
       return (angular.isNumber(closeValue) && closeValue === 0)
-              || (angular.isString(closeValue) && (closeValue === '$document' || closeValue === '$closeButton'));
+              || (angular.isString(closeValue)
+                && (closeValue === '$document'
+                  || closeValue === '$closeButton'));
     };
 
     // show the default projects directory to choose a folder from

--- a/public/assets/sass/_components/_projectTree.scss
+++ b/public/assets/sass/_components/_projectTree.scss
@@ -1,4 +1,0 @@
-.project-tree-container {
-  max-height: 600px;
-  overflow: auto;
-}


### PR DESCRIPTION
# Change Summary

 - fix scroll for project modal after file tree encapsulation (probably happened because of a bad merge ( @ortichon :wink: )) [resolved #103 ]
 
 > first try to fix this thing didn't work because the `ng-scrollbars` directive don't have any content. updated to wait for having a path to load using `ng-if`

- fix closing modal with all three `cancel` options should **not affect the main file tree or project name** [resolves #102 ]
 
- [x] did you link this PR to an issue?
- [x] did you lint your changes to both javascript and scss?
- [x] "I'm pretty sure I'll be able to read and understand this PR, even if I wasn't the author." - ***said the PR author***

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kibibit/kibibit-code-editor/101)
<!-- Reviewable:end -->
