### PR TITLE
Remove sub-folders from open folders array when closing it's parent

### DIFF
--- a/public/app/components/fileTree/fileTree.js
+++ b/public/app/components/fileTree/fileTree.js
@@ -81,20 +81,12 @@ angular.module('kibibitCodeEditor')
     };
 
     var closeFolder = function(folder) {
-      var folderIndex = vm.expandedNodes.indexOf(folder);
-      var isFolderOpen = folderIndex > -1;
-      var subFolders = folder.children;
-
-      //Close all the sub-folders as well
-      if (subFolders && subFolders.length > 0) {
-        subFolders.forEach(function(subFolder) {
-          closeFolder(subFolder);
-        });
-      }
-
-      if (isFolderOpen) {
-        vm.expandedNodes.splice(folderIndex, 1);
-      }
+      var nameIndex = folder.path.indexOf(folder.name);
+      var pathPrefix = folder.path.substr(0, nameIndex) + folder.name;
+      
+      vm.expandedNodes = vm.expandedNodes.filter(function(node) {
+        return node.path.indexOf(pathPrefix) === -1;
+      });
     };
   }]);
 

--- a/public/app/components/fileTree/fileTree.js
+++ b/public/app/components/fileTree/fileTree.js
@@ -83,7 +83,7 @@ angular.module('kibibitCodeEditor')
     var closeFolder = function(folder) {
       var nameIndex = folder.path.indexOf(folder.name);
       var pathPrefix = folder.path.substr(0, nameIndex) + folder.name;
-      
+
       vm.expandedNodes = vm.expandedNodes.filter(function(node) {
         return node.path.indexOf(pathPrefix) === -1;
       });

--- a/public/app/components/fileTree/fileTree.js
+++ b/public/app/components/fileTree/fileTree.js
@@ -81,11 +81,8 @@ angular.module('kibibitCodeEditor')
     };
 
     var closeFolder = function(folder) {
-      var nameIndex = folder.path.indexOf(folder.name);
-      var pathPrefix = folder.path.substr(0, nameIndex) + folder.name;
-
       vm.expandedNodes = vm.expandedNodes.filter(function(node) {
-        return !node.path.startsWith(pathPrefix);
+        return !node.path.startsWith(folder.path);
       });
     };
   }]);

--- a/public/app/components/fileTree/fileTree.js
+++ b/public/app/components/fileTree/fileTree.js
@@ -85,7 +85,7 @@ angular.module('kibibitCodeEditor')
       var pathPrefix = folder.path.substr(0, nameIndex) + folder.name;
 
       vm.expandedNodes = vm.expandedNodes.filter(function(node) {
-        return node.path.indexOf(pathPrefix) === -1;
+        return !node.path.startsWith(pathPrefix);
       });
     };
   }]);

--- a/public/app/components/fileTree/fileTree.js
+++ b/public/app/components/fileTree/fileTree.js
@@ -57,17 +57,18 @@ angular.module('kibibitCodeEditor')
       var folder;
       if (treeNode.type == 'directory') {
         folder = treeNode;
-        var directoryIndex = vm.expandedNodes.indexOf(folder);
-        var isDirectoryOpen = directoryIndex > -1;
-        if (isDirectoryOpen) {
-          // contract directory
-          vm.expandedNodes.splice(directoryIndex, 1);
+        var folderIndex = vm.expandedNodes.indexOf(folder);
+        var isFolderOpen = folderIndex > -1;
+
+        if (isFolderOpen) {
+          closeFolder(folder);
         } else {
           FolderService.getFolder(folder.path, function(folderContent) {
             folder.children = folderContent.data.children;
           });
           vm.expandedNodes.push(folder);
         }
+
         if (vm.options.selectionMode == 'folder') {
           vm.selection = folder.path;
         }
@@ -78,5 +79,22 @@ angular.module('kibibitCodeEditor')
         }
       }
     };
+
+    var closeFolder = function(folder) {
+      var folderIndex = vm.expandedNodes.indexOf(folder);
+      var isFolderOpen = folderIndex > -1;
+      var subFolders = folder.children;
+
+      //Close all the sub-folders as well
+      if (subFolders && subFolders.length > 0) {
+        subFolders.forEach(function(subFolder) {
+          closeFolder(subFolder);
+        })
+      }
+
+      if (isFolderOpen) {
+        vm.expandedNodes.splice(folderIndex, 1);
+      }
+    }
   }]);
 

--- a/public/app/components/fileTree/fileTree.js
+++ b/public/app/components/fileTree/fileTree.js
@@ -89,12 +89,12 @@ angular.module('kibibitCodeEditor')
       if (subFolders && subFolders.length > 0) {
         subFolders.forEach(function(subFolder) {
           closeFolder(subFolder);
-        })
+        });
       }
 
       if (isFolderOpen) {
         vm.expandedNodes.splice(folderIndex, 1);
       }
-    }
+    };
   }]);
 


### PR DESCRIPTION
# Change Summary

 - Created recursive "close folder" function [resolves #121 ]
 
 > 
 
## More info

the function iterates trough all the current sub-folders, checks if they have additional open sub-folders, and remove them all from the `expandedNodes` array

Before you submit a PR, make sure you did the following things:
- [x] did you link this PR to an issue?

>> Make sure there's an issue open about the change you did *(open one if there isn't)*. link this PR to that issue by writing `resolves #{{issue_number}}`. If this PR had several mission, link each issue in its parallel mission.

- [x] did you lint your changes to both javascript and scss?

>> hound can be **pretty rough** at keeping our code clean and readable! make sure you format your code by running either `gulp format` or `gulp lint` and cleaning out all the ***lint errors***. If you won't, you'll have a ***long conversation*** with hound :-)

- [x] "I'm pretty sure I'll be able to read and understand this PR, even if I wasn't the author." - ***said the PR author***
