### PR TITLE
[Feature] Support images 2

### DIFF
--- a/app/models/fileService.js
+++ b/app/models/fileService.js
@@ -1,6 +1,6 @@
 var dirTree = require('directory-tree'),
     fs = require('fs'),
-    util = require("util"),
+    util = require('util'),
     mime = require('mime-types');
 var console = process.console;
 
@@ -191,8 +191,8 @@ fileService.getFileTags = function(filepath) {
 };
 
 function base64Image(src) {
-    var data = fs.readFileSync(src).toString("base64");
-    return util.format("data:%s;base64,%s", mime.lookup(src), data);
+    var data = fs.readFileSync(src).toString('base64');
+    return util.format('data:%s;base64,%s', mime.lookup(src), data);
 }
 
 function extraTypes(filepath) {

--- a/app/models/fileService.js
+++ b/app/models/fileService.js
@@ -30,8 +30,7 @@ fileService.get = function(req, res) {
       mimeType: 'text/text'
     });
   } else if (isFileOfType('image')) {
-    console.time().tag('FILE CONTENT')
-          .info('image requested. Serving data URI');
+    console.info('image requested. Serving data URI');
     var dataUri = base64Image(fileFullPath);
     var file = {
       content: dataUri,

--- a/app/models/fileService.js
+++ b/app/models/fileService.js
@@ -184,8 +184,8 @@ fileService.getFileTags = function(filepath) {
 };
 
 function base64Image(src) {
-    var data = fs.readFileSync(src).toString('base64');
-    return util.format('data:%s;base64,%s', mime.lookup(src), data);
+  var data = fs.readFileSync(src).toString('base64');
+  return util.format('data:%s;base64,%s', mime.lookup(src), data);
 }
 
 function extraTypes(filepath) {

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
     "json-formatter": "~0.5.0",
     "velocity": "~1.2.3",
     "ngclipboard": "~1.1.1",
-    "ng-device-detector": "~3.0.1"
+    "ng-device-detector": "~3.0.1",
+    "viewerjs": "fengyuanchen/viewerjs#~0.4.0"
   },
   "resolutions": {
     "angular": "1.5.5"

--- a/public/app/components/codeEditor/codeEditor.js
+++ b/public/app/components/codeEditor/codeEditor.js
@@ -81,16 +81,14 @@ angular.module('kibibitCodeEditor')
       onChange: vm.aceChanged
     };
 
-    vm.updateFileContent = function(filePath) {
-      if (filePath !== '') {
-        FileService.getFile(filePath, function(fileInfo) {
-          vm.fileInfo = fileInfo.data;
-          vm.code = vm.fileInfo.content;
-          var fileMode = getModeFromMimeType(vm.fileInfo);
-          editorSettings.syntaxMode = fileMode;
-          vm.parsedJson = undefined;
-          console.debug('changed mode to ' + fileMode);
-        });
+    vm.updateFileContent = function(fileObject) {
+      if (fileObject) {
+        vm.fileInfo = fileObject;
+        vm.code = vm.fileInfo.content;
+        var fileMode = getModeFromMimeType(vm.fileInfo);
+        editorSettings.syntaxMode = fileMode;
+        vm.parsedJson = undefined;
+        console.debug('changed mode to ' + fileMode);
       }
     };
 

--- a/public/app/components/fullImageView/fullImageView.js
+++ b/public/app/components/fullImageView/fullImageView.js
@@ -1,0 +1,42 @@
+angular.module('kibibitCodeEditor')
+
+.directive('kbFullImageView', function() {
+  return {
+    scope: {},
+    controller: 'fullImageViewController',
+    controllerAs: 'fullImageViewCtrl',
+    link: function(scope, element, attrs, fullImageViewCtrl) {
+      fullImageViewCtrl.addFullImageView(element);
+
+      scope.$watch(function() {
+        return element.attr('src');
+      }, function() {
+        if (fullImageViewCtrl.viewer) {
+          fullImageViewCtrl.viewer.update();
+        }
+      });
+    }
+  };
+})
+
+.controller('fullImageViewController', [
+  function() {
+    var vm = this;
+
+    vm.addFullImageView = function(element) {
+      if (window.Viewer) {
+        element.css({
+          visibility: 'hidden'
+        });
+        // View one image
+        vm.viewer = new Viewer(element[0], {
+          inline: true,
+          title: false,
+          button: false,
+          navbar: false
+        });
+      }
+    };
+
+  }
+]);

--- a/public/app/components/viewByFile/viewByFile.js
+++ b/public/app/components/viewByFile/viewByFile.js
@@ -27,16 +27,16 @@ angular.module('kibibitCodeEditor')
         FileService.getFile(filePath, function(fileInfo) {
           vm.fileInfo = fileInfo.data;
           vm.fileType = getFileTypeFromMimeType(vm.fileInfo.mimeType);
-          vm.imageUri = vm.fileType === "image" ? vm.fileInfo.content : undefined;
+          vm.imageUri = vm.fileType === 'image' ? vm.fileInfo.content : undefined;
         });
       }
     };
 
     function getFileTypeFromMimeType(mimeType) {
       if (mimeType.indexOf('image') !== -1) {
-        return "image";
+        return 'image';
       } else {
-        return "code";
+        return 'code';
       }
     }
 

--- a/public/app/components/viewByFile/viewByFile.js
+++ b/public/app/components/viewByFile/viewByFile.js
@@ -1,0 +1,44 @@
+angular.module('kibibitCodeEditor')
+
+.directive('kbViewByFile', function() {
+  return {
+    scope: {},
+    bindToController: {
+      openFile: '=kbOpenFile'
+    },
+    controller: 'viewByFileController',
+    controllerAs: 'viewByFileCtrl',
+    templateUrl: 'app/components/viewByFile/viewByFileTemplate.html',
+    link: function(scope, element, attrs, viewByFileCtrl) {
+      scope.$watch('viewByFileCtrl.openFile', function(newOpenFile) {
+        viewByFileCtrl.updateFileContent(newOpenFile);
+      });
+    }
+  };
+})
+
+.controller('viewByFileController', [
+  'FileService',
+  function(FileService) {
+    var vm = this;
+
+    vm.updateFileContent = function(filePath) {
+      if (filePath !== '') {
+        FileService.getFile(filePath, function(fileInfo) {
+          vm.fileInfo = fileInfo.data;
+          vm.fileType = getFileTypeFromMimeType(vm.fileInfo.mimeType);
+          vm.imageUri = vm.fileType === "image" ? vm.fileInfo.content : undefined;
+        });
+      }
+    };
+
+    function getFileTypeFromMimeType(mimeType) {
+      if (mimeType.indexOf('image') !== -1) {
+        return "image";
+      } else {
+        return "code";
+      }
+    }
+
+  }
+]);

--- a/public/app/components/viewByFile/viewByFileTemplate.html
+++ b/public/app/components/viewByFile/viewByFileTemplate.html
@@ -1,6 +1,6 @@
 <div class="view-by-file" ng-switch="viewByFileCtrl.fileType">
 	<kb-code-editor kb-open-file="viewByFileCtrl.openFile" ng-switch-default></kb-code-editor>
-	<div class="img-view-container">
-		<img kb-full-image-view class="img-view" ng-src="{{ viewByFileCtrl.imageUri }}" ng-switch-when="image">
+	<div class="img-view-container" ng-switch-when="image">
+		<img kb-full-image-view class="img-view" ng-src="{{ viewByFileCtrl.imageUri }}">
 	</div>
 </div>

--- a/public/app/components/viewByFile/viewByFileTemplate.html
+++ b/public/app/components/viewByFile/viewByFileTemplate.html
@@ -1,0 +1,6 @@
+<div class="view-by-file" ng-switch="viewByFileCtrl.fileType">
+	<kb-code-editor kb-open-file="viewByFileCtrl.openFile" ng-switch-default></kb-code-editor>
+	<div class="img-view-container">
+		<img class="img-view" ng-src="{{ viewByFileCtrl.imageUri }}" ng-switch-when="image">
+	</div>
+</div>

--- a/public/app/components/viewByFile/viewByFileTemplate.html
+++ b/public/app/components/viewByFile/viewByFileTemplate.html
@@ -1,5 +1,5 @@
 <div class="view-by-file" ng-switch="viewByFileCtrl.fileType">
-	<kb-code-editor kb-open-file="viewByFileCtrl.openFile" ng-switch-default></kb-code-editor>
+	<kb-code-editor kb-open-file="viewByFileCtrl.fileInfo" ng-switch-default></kb-code-editor>
 	<div class="img-view-container" ng-switch-when="image">
 		<img kb-full-image-view class="img-view" ng-src="{{ viewByFileCtrl.imageUri }}">
 	</div>

--- a/public/app/components/viewByFile/viewByFileTemplate.html
+++ b/public/app/components/viewByFile/viewByFileTemplate.html
@@ -1,6 +1,6 @@
 <div class="view-by-file" ng-switch="viewByFileCtrl.fileType">
 	<kb-code-editor kb-open-file="viewByFileCtrl.openFile" ng-switch-default></kb-code-editor>
 	<div class="img-view-container">
-		<img class="img-view" ng-src="{{ viewByFileCtrl.imageUri }}" ng-switch-when="image">
+		<img kb-full-image-view class="img-view" ng-src="{{ viewByFileCtrl.imageUri }}" ng-switch-when="image">
 	</div>
 </div>

--- a/public/app/controllers/mainCtrl.js
+++ b/public/app/controllers/mainCtrl.js
@@ -4,13 +4,11 @@ angular.module('kibibitCodeEditor')
   '$scope',
   '$http',
   'ngDialog',
-  'Fullscreen',
   'SettingsService',
   function(
     $scope,
     $http,
     ngDialog,
-    Fullscreen,
     SettingsService) {
 
     var vm = this;

--- a/public/app/services/settingsService.js
+++ b/public/app/services/settingsService.js
@@ -203,7 +203,9 @@ angular.module('kibibitCodeEditor')
           }
 
           var matchedMode = CODE_EDITOR.MODE_LIST.modesByName[newValue];
-          matchedMode = matchedMode ? matchedMode : CODE_EDITOR.MODE_LIST.modesByName['text'];
+          matchedMode = matchedMode ?
+            matchedMode :
+            CODE_EDITOR.MODE_LIST.modesByName['text'];
 
           console.assert(matchedMode, {
             'message': ERROR_MSGS
@@ -273,5 +275,5 @@ angular.module('kibibitCodeEditor')
     function currentFullscreenState() {
       return $(window).data('fullscreen-state');
     }
-
-}]);
+  }
+]);

--- a/public/app/services/settingsService.js
+++ b/public/app/services/settingsService.js
@@ -198,7 +198,12 @@ angular.module('kibibitCodeEditor')
         });
 
         editorSettings.__defineSetter__('syntaxMode', function(newValue) {
+          if (!settings.currentEditor) {
+            return;
+          }
+
           var matchedMode = CODE_EDITOR.MODE_LIST.modesByName[newValue];
+          matchedMode = matchedMode ? matchedMode : CODE_EDITOR.MODE_LIST.modesByName['text'];
 
           console.assert(matchedMode, {
             'message': ERROR_MSGS

--- a/public/app/views/home.html
+++ b/public/app/views/home.html
@@ -1,2 +1,2 @@
 <kb-zombify ng-model="main.zombify" ng-if="main.zombify"></kb-zombify>
-<kb-code-editor kb-open-file="main.openFile"></kb-code-editor>
+<kb-view-by-file kb-open-file="main.openFile"></kb-view-by-file>

--- a/public/app/views/index.html
+++ b/public/app/views/index.html
@@ -25,6 +25,7 @@
     <link rel="stylesheet" type="text/css" href="assets/lib/bower_components/malihu-custom-scrollbar-plugin/jquery.mCustomScrollbar.min.css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.2.0/styles/default.min.css">
     <link rel="stylesheet" href="assets/lib/bower_components/angular-emoji/dist/emoji.min.css">
+    <link rel="stylesheet" type="text/css" href="assets/lib/bower_components/viewerjs/dist/viewer.css">
     <link href='//goo.gl/QatcDl' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="assets/css/style.css">
 </head>
@@ -115,6 +116,7 @@
     <script src="assets/lib/bower_components/angular-marked/dist/angular-marked.js"></script>
     <script src="assets/lib/highlight/highlight.pack.js"></script>
     <script src="assets/lib/bower_components/angular-emoji/dist/emoji.min.js"></script>
+    <script type="text/javascript" src="assets/lib/bower_components/viewerjs/dist/viewer.js"></script>
 
     <!-- Kibibit Code Editor -->
     <!-- Initialize -->
@@ -136,6 +138,7 @@
     <script type="text/javascript" src="app/components/movingGears/movingGears.js"></script>
     <script type="text/javascript" src="app/components/zombify/zombify.js"></script>
     <script type="text/javascript" src="app/components/viewByFile/viewByFile.js"></script>
+    <script type="text/javascript" src="app/components/fullImageView/fullImageView.js"></script>
     <!-- Services -->
     <!-- <script src="app/services/authService.js"></script> -->
     <script type="text/javascript" src="app/services/userService.js"></script>

--- a/public/app/views/index.html
+++ b/public/app/views/index.html
@@ -135,6 +135,7 @@
     <script type="text/javascript" src="app/components/errorView/errorView.js"></script>
     <script type="text/javascript" src="app/components/movingGears/movingGears.js"></script>
     <script type="text/javascript" src="app/components/zombify/zombify.js"></script>
+    <script type="text/javascript" src="app/components/viewByFile/viewByFile.js"></script>
     <!-- Services -->
     <!-- <script src="app/services/authService.js"></script> -->
     <script type="text/javascript" src="app/services/userService.js"></script>

--- a/public/assets/sass/_components/_viewByFile.scss
+++ b/public/assets/sass/_components/_viewByFile.scss
@@ -1,0 +1,35 @@
+kb-view-by-file {
+  .view-by-file {
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+
+    .img-view-container {
+      height: 100%;
+      overflow-x: hidden;
+      text-align: center;
+      vertical-align: top; /* inner img is centered horizontally */
+      width: 100%; /* needed */
+
+      .img-view{
+        bottom: 0;
+        left: 0;
+        margin: auto;
+        max-height: 70%;
+        max-width: 70%;
+        object-fit: contain;
+        padding: auto;
+        position: absolute;
+        right: 0;
+        top: 0;
+      }
+
+      .viewer-prev,
+      .viewer-next {
+        display: none;
+      }
+    }
+  }
+}

--- a/public/assets/sass/style.scss
+++ b/public/assets/sass/style.scss
@@ -271,7 +271,7 @@ md-input-container {
   position: absolute;
   right: 0;
   top: 0;
-  
+
   .img-view-container {
     height: 100%;
     overflow-x: hidden;
@@ -292,7 +292,8 @@ md-input-container {
       top: 0;
     }
 
-    li.viewer-prev, li.viewer-next {
+    .viewer-prev,
+    .viewer-next {
       display: none;
     }
   }

--- a/public/assets/sass/style.scss
+++ b/public/assets/sass/style.scss
@@ -290,6 +290,10 @@ md-input-container {
       right: 0;
       top: 0;
     }
+
+    li.viewer-prev, li.viewer-next {
+      display: none;
+    }
   }
 }
 

--- a/public/assets/sass/style.scss
+++ b/public/assets/sass/style.scss
@@ -265,40 +265,6 @@ md-input-container {
   }
 }
 
-.view-by-file {
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-
-  .img-view-container {
-    height: 100%;
-    overflow-x: hidden;
-    text-align: center;
-    vertical-align: top; /* inner img is centered horizontally */
-    width: 100%; /* needed */
-
-    .img-view{
-      bottom: 0;
-      left: 0;
-      margin: auto;
-      max-height: 70%;
-      max-width: 70%;
-      object-fit: contain;
-      padding: auto;
-      position: absolute;
-      right: 0;
-      top: 0;
-    }
-
-    .viewer-prev,
-    .viewer-next {
-      display: none;
-    }
-  }
-}
-
 // scss-lint:disable IdSelector
 #loading-bar-spinner .spinner-icon {
   border: solid 4px transparent;

--- a/public/assets/sass/style.scss
+++ b/public/assets/sass/style.scss
@@ -265,6 +265,34 @@ md-input-container {
   }
 }
 
+.view-by-file {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  .img-view-container {
+    height:100%;
+    overflow-x:hidden;
+    text-align:center;
+    vertical-align:top; /* inner img is centered horizontally */
+    width:100%; /* needed */
+
+    .img-view{
+      bottom: 0;
+      left: 0;
+      margin: auto;
+      max-height: 70%;
+      max-width: 70%;
+      object-fit: contain;
+      padding: auto;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+  }
+}
+
 // scss-lint:disable IdSelector
 #loading-bar-spinner .spinner-icon {
   border: solid 4px transparent;

--- a/public/assets/sass/style.scss
+++ b/public/assets/sass/style.scss
@@ -271,12 +271,13 @@ md-input-container {
   position: absolute;
   right: 0;
   top: 0;
+  
   .img-view-container {
-    height:100%;
-    overflow-x:hidden;
-    text-align:center;
-    vertical-align:top; /* inner img is centered horizontally */
-    width:100%; /* needed */
+    height: 100%;
+    overflow-x: hidden;
+    text-align: center;
+    vertical-align: top; /* inner img is centered horizontally */
+    width: 100%; /* needed */
 
     .img-view{
       bottom: 0;


### PR DESCRIPTION
# Change Summary

 - view select component [ resolves #79 ]
 
 > Selects the correct view by the mimeType of the received file. Currently, supports `code` for the code editor, and `image` for the image viewer
 
 - serve images as dataURI, and fonts as a file download [ relates to #77 ]

> Still need to check if this is good enough for showing fonts. This will be clear when we'll do #82

 - `fullImageView`component to show images with some fancy actions 😄  [ resolves #81 ]
 
## More info

Still needs a lot of work. but it's cool nonetheless

Before you submit a PR, make sure you did the following things:
- [x] did you link this PR to an issue?
- [x] did you lint your changes to both javascript and scss?
- [x] "I'm pretty sure I'll be able to read and understand this PR, even if I wasn't the author." - ***said the PR author***
